### PR TITLE
Add line filter to map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# rb-map
+# Ruhrbahn Vehicle Map
+
+A small Flask application that displays live positions of Ruhrbahn vehicles on a Leaflet map.
+
+## Requirements
+
+- Python 3.11 or newer
+- `flask` and `requests` packages
+
+Install dependencies with:
+
+```bash
+pip install flask requests
+```
+
+## Usage
+
+Run the application:
+
+```bash
+python app.py
+```
+
+Open `http://localhost:8021` in your browser.
+
+Use the dropdown to filter vehicles by line. The map refreshes automatically every 15 seconds.
+

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ def index():
 
 @app.route('/api/vehicles')
 def get_vehicles():
+    """Return vehicle positions optionally filtered by line."""
     line_filter = request.args.get("line")
     url = "https://www.ruhrbahn.de/efaws2/default/XML_VEHICLE_MONITOR_REQUEST"
     response = requests.get(url, params={"outputFormat": "JSON"})
@@ -28,6 +29,17 @@ def get_vehicles():
                 "direction": v.get("direction", "?")
             })
     return jsonify(vehicles)
+
+
+@app.route('/api/lines')
+def get_lines():
+    """Return a list of available line numbers."""
+    url = "https://www.ruhrbahn.de/efaws2/default/XML_VEHICLE_MONITOR_REQUEST"
+    response = requests.get(url, params={"outputFormat": "JSON"})
+    response.raise_for_status()
+    data = response.json()
+    lines = sorted({v["number"] for v in data.get("vehicles", []) if v.get("number")})
+    return jsonify(lines)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8021, debug=True)

--- a/static/map.js
+++ b/static/map.js
@@ -3,10 +3,26 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap-Mitwirkende'
 }).addTo(map);
 
+function loadLines() {
+  fetch('/api/lines')
+    .then(res => res.json())
+    .then(lines => {
+      const select = document.getElementById('line-filter');
+      lines.forEach(line => {
+        const opt = document.createElement('option');
+        opt.value = line;
+        opt.textContent = line;
+        select.appendChild(opt);
+      });
+    });
+}
+
 let markers = {};
 
 function updateVehicles() {
-  fetch('/api/vehicles')
+  const line = document.getElementById('line-filter').value;
+  const url = line ? `/api/vehicles?line=${encodeURIComponent(line)}` : '/api/vehicles';
+  fetch(url)
     .then(res => res.json())
     .then(data => {
       for (const id in markers) {
@@ -23,5 +39,6 @@ function updateVehicles() {
     });
 }
 
+loadLines();
 updateVehicles();
 setInterval(updateVehicles, 15000);

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,9 @@
   </style>
 </head>
 <body>
+  <select id="line-filter">
+    <option value="">Alle Linien</option>
+  </select>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="/static/map.js"></script>


### PR DESCRIPTION
## Summary
- build list of available lines and add `/api/lines`
- add line filter dropdown in the HTML
- update map JavaScript to load lines and send selected line
- document how to run the app

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6859b2b8a7f08321aa009611e3ea7f63