### PR TITLE
Add script for VRR API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ Open `http://localhost:8021` in your browser.
 
 Use the dropdown to filter vehicles by line. The map refreshes automatically every 15 seconds.
 
+## VRR Stop Visit Script
+
+The repository also contains a small helper script `efa_stop_visits.py` that
+fetches live departures for a single stop via the public EFA VRR API. Run it
+with Python to print the currently monitored lines, courses and stops:
+
+```bash
+python efa_stop_visits.py
+```
+
+You can change the `stop_id` in the script to query another stop.
+

--- a/efa_stop_visits.py
+++ b/efa_stop_visits.py
@@ -1,0 +1,42 @@
+import requests
+
+
+def fetch_stop_visits(stop_id: str) -> dict:
+    """Return JSON data for upcoming visits at a stop from the EFA VRR API."""
+    url = "https://efa.vrr.de/standard/XML_STOPVISIT_REQUEST"
+    params = {
+        "language": "de",
+        "outputFormat": "JSON",
+        "coordOutputFormat": "WGS84[DD.ddddd]",
+        "siteid": "VRR",
+        "stop": stop_id,
+    }
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def show_active_vehicles(data: dict) -> None:
+    """Print information about all active vehicles in the response."""
+    visits = data.get("stopVisits", [])
+    for visit in visits:
+        journey = visit.get("monitoredVehicleJourney", {})
+        call = journey.get("monitoredCall", {})
+        location = journey.get("vehicleLocation", {})
+        print(
+            f"Linie {journey.get('lineRef')} | Kurs {journey.get('courseOfJourneyRef')}"
+        )
+        print(f"Richtung: {journey.get('directionName')}")
+        print(f"Haltestelle: {call.get('stopPointRef')}")
+        print(
+            f"Geoposition: {location.get('latitude')}, {location.get('longitude')}"
+        )
+        print(f"Geplante Ankunft: {call.get('aimedArrivalTime')}")
+        print("-" * 40)
+
+
+if __name__ == "__main__":
+    # Example stop: Franziskanerstra\u00dfe Essen
+    stop_id = "de:05113:7056"
+    data = fetch_stop_visits(stop_id)
+    show_active_vehicles(data)


### PR DESCRIPTION
## Summary
- add `efa_stop_visits.py` to query the public EFA VRR API for live departures
- document usage in README

## Testing
- `python efa_stop_visits.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859cefb4940832196adbb56c6d2552f