### PR TITLE
Fix stop visit script error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Use the dropdown to filter vehicles by line. The map refreshes automatically eve
 
 The repository also contains a small helper script `efa_stop_visits.py` that
 fetches live departures for a single stop via the public EFA VRR API. Run it
-with Python to print the currently monitored lines, courses and stops:
+with Python to print the currently monitored lines, courses and stops. If the
+API request fails, the script prints an error message:
 
 ```bash
 python efa_stop_visits.py

--- a/efa_stop_visits.py
+++ b/efa_stop_visits.py
@@ -1,8 +1,11 @@
 import requests
 
 
-def fetch_stop_visits(stop_id: str) -> dict:
-    """Return JSON data for upcoming visits at a stop from the EFA VRR API."""
+def fetch_stop_visits(stop_id: str) -> dict | None:
+    """Return JSON data for upcoming visits at a stop from the EFA VRR API.
+
+    Returns ``None`` if the request fails for any reason.
+    """
     url = "https://efa.vrr.de/standard/XML_STOPVISIT_REQUEST"
     params = {
         "language": "de",
@@ -11,13 +14,20 @@ def fetch_stop_visits(stop_id: str) -> dict:
         "siteid": "VRR",
         "stop": stop_id,
     }
-    response = requests.get(url, params=params, timeout=10)
-    response.raise_for_status()
-    return response.json()
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        print(f"Failed to fetch stop visits: {exc}")
+        return None
 
 
-def show_active_vehicles(data: dict) -> None:
+def show_active_vehicles(data: dict | None) -> None:
     """Print information about all active vehicles in the response."""
+    if data is None:
+        print("No data available")
+        return
     visits = data.get("stopVisits", [])
     for visit in visits:
         journey = visit.get("monitoredVehicleJourney", {})


### PR DESCRIPTION
## Summary
- make `efa_stop_visits.py` resilient against HTTP errors
- mention error message behaviour in README

## Testing
- `python -m py_compile app.py efa_stop_visits.py`
- `python3 efa_stop_visits.py` *(fails to connect to efa.vrr.de)*

------
https://chatgpt.com/codex/tasks/task_e_6859d3d781c883218add8e577c2aa8fe