### PR TITLE
Update stop visit script to use name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ API request fails, the script prints an error message:
 python efa_stop_visits.py
 ```
 
-You can change the `stop_id` in the script to query another stop.
+You can change the stop name in the script to query another stop.
 


### PR DESCRIPTION
## Summary
- fetch VRR stop visits by stop name instead of stop ID
- adjust README for new script usage

## Testing
- `python efa_stop_visits.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859d50397f883218fe3b9d6769ca3be