### PR TITLE
Add GTFS realtime tram map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ruhrbahn Vehicle Map
+# VRR Tram Map
 
-A small Flask application that displays live positions of Ruhrbahn vehicles on a Leaflet map.
+A Flask web application that visualises live tram positions in the VRR region.
 
 ## Requirements
 
@@ -10,7 +10,7 @@ A small Flask application that displays live positions of Ruhrbahn vehicles on a
 Install dependencies with:
 
 ```bash
-pip install flask requests
+pip install flask requests protobuf
 ```
 
 ## Usage
@@ -23,7 +23,8 @@ python app.py
 
 Open `http://localhost:8021` in your browser.
 
-Use the dropdown to filter vehicles by line. The map refreshes automatically every 15 seconds.
+Use the dropdown or the URL parameter `?line=107` to filter vehicles by line.
+The map refreshes automatically every 15 seconds.
 
 ## VRR Stop Visit Script
 

--- a/app.py
+++ b/app.py
@@ -1,64 +1,75 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
 from flask import Flask, jsonify, render_template, request
 import requests
+from google.transit import gtfs_realtime_pb2
 
 app = Flask(__name__)
 
+GTFS_URL = "https://realtime.gtfs.de/realtime-free.pb"
 
-def fetch_ruhrbahn_data() -> dict | None:
-    """Fetch data from the Ruhrbahn API and return the parsed JSON.
+# in-memory cache for the decoded feed
+_FEED_CACHE: Dict[str, Any] = {"timestamp": 0.0, "vehicles": []}
 
-    Returns None if the request fails for any reason.
-    """
-    url = "https://www.ruhrbahn.de/efaws2/default/XML_VEHICLE_MONITOR_REQUEST"
+
+def load_gtfs_feed() -> List[Dict[str, Any]]:
+    """Load and parse the GTFS-Realtime feed with a 10s cache."""
+    now = time.time()
+    if now - _FEED_CACHE["timestamp"] < 10:
+        return _FEED_CACHE["vehicles"]
+
     try:
-        response = requests.get(url, params={"outputFormat": "JSON"}, timeout=10)
-        response.raise_for_status()
-        return response.json()
+        resp = requests.get(GTFS_URL, timeout=10)
+        resp.raise_for_status()
     except requests.RequestException as exc:
-        app.logger.exception("Ruhrbahn API request failed: %s", exc)
-        return None
+        app.logger.exception("Failed to fetch GTFS feed: %s", exc)
+        return _FEED_CACHE["vehicles"]
 
-@app.route('/')
-def index():
-    return render_template('index.html')
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.ParseFromString(resp.content)
 
-@app.route('/api/vehicles')
-def get_vehicles():
-    """Return vehicle positions optionally filtered by line."""
-    line_filter = request.args.get("line")
-    data = fetch_ruhrbahn_data()
-    if data is None:
-        return (
-            jsonify({"error": "Failed to fetch data from Ruhrbahn API"}),
-            502,
+    vehicles: List[Dict[str, Any]] = []
+    for entity in feed.entity:
+        if not entity.HasField("vehicle"):
+            continue
+        vehicle = entity.vehicle
+        pos = vehicle.position
+        if not pos.HasField("latitude") or not pos.HasField("longitude"):
+            continue
+        trip = vehicle.trip
+        vehicles.append(
+            {
+                "line": trip.route_id or trip.trip_id,
+                "course": vehicle.vehicle.label or trip.trip_id,
+                "lat": pos.latitude,
+                "lon": pos.longitude,
+                "direction": getattr(pos, "bearing", 0.0),
+                "timestamp": vehicle.timestamp or feed.header.timestamp,
+            }
         )
 
-    vehicles = []
-    for v in data.get("vehicles", []):
-        if "position" in v and v.get("number") and v.get("course"):
-            if line_filter and v["number"] != line_filter:
-                continue
-            vehicles.append({
-                "lat": v["position"]["lat"],
-                "lon": v["position"]["lon"],
-                "line": v["number"],
-                "course": v["course"],
-                "direction": v.get("direction", "?")
-            })
+    _FEED_CACHE["timestamp"] = now
+    _FEED_CACHE["vehicles"] = vehicles
+    return vehicles
+
+
+@app.route("/")
+def index() -> str:
+    line = request.args.get("line", "")
+    return render_template("index.html", line=line)
+
+
+@app.route("/vehicles")
+def get_vehicles() -> Any:
+    line_filter = request.args.get("line")
+    vehicles = load_gtfs_feed()
+    if line_filter:
+        vehicles = [v for v in vehicles if v["line"] == line_filter]
     return jsonify(vehicles)
 
 
-@app.route('/api/lines')
-def get_lines():
-    """Return a list of available line numbers."""
-    data = fetch_ruhrbahn_data()
-    if data is None:
-        return (
-            jsonify({"error": "Failed to fetch data from Ruhrbahn API"}),
-            502,
-        )
-    lines = sorted({v["number"] for v in data.get("vehicles", []) if v.get("number")})
-    return jsonify(lines)
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8021, debug=True)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8021)

--- a/static/map.js
+++ b/static/map.js
@@ -1,43 +1,67 @@
-const map = L.map('map').setView([51.45, 7.01], 13);
+const map = L.map('map').setView([51.4556, 7.0116], 13);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  attribution: '© OpenStreetMap-Mitwirkende'
+  attribution: '© OpenStreetMap contributors'
 }).addTo(map);
 
+let selectedLine = typeof INITIAL_LINE !== 'undefined' ? INITIAL_LINE : '';
+const markers = {};
+
+function getColor(line) {
+  const colors = ['red', 'blue', 'green', 'orange', 'purple', 'brown'];
+  let idx = 0;
+  for (let i = 0; i < line.length; i++) {
+    idx = (idx + line.charCodeAt(i)) % colors.length;
+  }
+  return colors[idx];
+}
+
 function loadLines() {
-  fetch('/api/lines')
-    .then(res => res.json())
-    .then(lines => {
+  fetch('/vehicles')
+    .then(r => r.json())
+    .then(data => {
       const select = document.getElementById('line-filter');
-      lines.forEach(line => {
+      const lines = [...new Set(data.map(v => v.line))].sort();
+      lines.forEach(l => {
         const opt = document.createElement('option');
-        opt.value = line;
-        opt.textContent = line;
+        opt.value = l;
+        opt.textContent = l;
+        if (l === selectedLine) opt.selected = true;
         select.appendChild(opt);
       });
     });
 }
 
-let markers = {};
-
 function updateVehicles() {
-  const line = document.getElementById('line-filter').value;
-  const url = line ? `/api/vehicles?line=${encodeURIComponent(line)}` : '/api/vehicles';
+  const url = selectedLine ? `/vehicles?line=${encodeURIComponent(selectedLine)}` : '/vehicles';
   fetch(url)
-    .then(res => res.json())
+    .then(r => r.json())
     .then(data => {
-      for (const id in markers) {
-        map.removeLayer(markers[id]);
+      for (const key in markers) {
+        map.removeLayer(markers[key]);
       }
-      markers = {};
-
-      data.forEach(v => {
+      for (const v of data) {
         const key = `${v.line}-${v.course}`;
-        const marker = L.marker([v.lat, v.lon]).addTo(map)
-          .bindPopup(`<b>Linie:</b> ${v.line}<br><b>Kurs:</b> ${v.course}`);
+        const icon = L.divIcon({
+          className: '',
+          html: `<div class="tram-marker" style="border-bottom-color:${getColor(v.line)}"></div>`,
+          iconSize: [16, 16],
+          iconAnchor: [8, 8]
+        });
+        const marker = L.marker([v.lat, v.lon], { icon, rotationAngle: v.direction }).addTo(map);
+        marker.bindPopup(`<b>Linie:</b> ${v.line}<br><b>Kurs:</b> ${v.course}`);
         markers[key] = marker;
-      });
+      }
     });
 }
+
+document.getElementById('line-filter').addEventListener('change', ev => {
+  const line = ev.target.value;
+  if (line) {
+    window.location.search = '?line=' + encodeURIComponent(line);
+  } else {
+    window.location.search = location.pathname;
+  }
+});
 
 loadLines();
 updateVehicles();

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,10 +2,19 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <title>Ruhrbahn Fahrzeugkarte</title>
+  <title>VRR Tram Map</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet-rotatedmarker/leaflet.rotatedMarker.js"></script>
   <style>
     #map { height: 100vh; }
+    .tram-marker {
+      width: 0;
+      height: 0;
+      border-left: 8px solid transparent;
+      border-right: 8px solid transparent;
+      border-bottom: 14px solid red;
+      display: block;
+    }
   </style>
 </head>
 <body>
@@ -14,6 +23,9 @@
   </select>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script>
+    const INITIAL_LINE = "{{ line }}";
+  </script>
   <script src="/static/map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement GTFS-Realtime loader in `app.py` with caching and filtering
- show chosen line in template, add rotated marker support
- update map logic to fetch vehicles from `/vehicles`
- refresh README to document GTFS usage

## Testing
- `python -m py_compile app.py`
- `python -m py_compile efa_stop_visits.py efa_tram_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_6859e8f216a08321b439476fa37814d2