### PR TITLE
Add line list generation and course dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Open `http://localhost:8021` in your browser.
 Use the dropdown or the URL parameter `?line=107` to filter vehicles by line.
 The map refreshes automatically every 15 seconds.
 
+### Generate line list
+
+The helper script `generate_line_list.py` creates a file `data/line.txt`
+containing all lines currently present in the GTFS feed:
+
+```bash
+python generate_line_list.py
+```
+
+The web application reads this file for the dropdown if it exists.
+
 ## VRR Stop Visit Script
 
 The repository also contains a small helper script `efa_stop_visits.py` that

--- a/generate_line_list.py
+++ b/generate_line_list.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Generate a list of tram lines from the GTFS feed."""
+
+from typing import List
+from app import load_gtfs_feed
+
+
+def main() -> None:
+    vehicles = load_gtfs_feed()
+    lines: List[str] = sorted({v["line"] for v in vehicles})
+    with open("data/line.txt", "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(f"{line}\n")
+    print(f"Wrote {len(lines)} lines to data/line.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/map.js
+++ b/static/map.js
@@ -4,6 +4,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 
 let selectedLine = typeof INITIAL_LINE !== 'undefined' ? INITIAL_LINE : '';
+let selectedCourse = typeof INITIAL_COURSE !== 'undefined' ? INITIAL_COURSE : '';
 const markers = {};
 
 function getColor(line) {
@@ -16,11 +17,11 @@ function getColor(line) {
 }
 
 function loadLines() {
-  fetch('/vehicles')
+  fetch('/lines')
     .then(r => r.json())
-    .then(data => {
+    .then(lines => {
       const select = document.getElementById('line-filter');
-      const lines = [...new Set(data.map(v => v.line))].sort();
+      select.innerHTML = '<option value="">Alle Linien</option>';
       lines.forEach(l => {
         const opt = document.createElement('option');
         opt.value = l;
@@ -28,11 +29,41 @@ function loadLines() {
         if (l === selectedLine) opt.selected = true;
         select.appendChild(opt);
       });
+      if (selectedLine) {
+        loadCourses(selectedLine);
+      }
+    });
+}
+
+function loadCourses(line) {
+  fetch(`/courses?line=${encodeURIComponent(line)}`)
+    .then(r => r.json())
+    .then(courses => {
+      const select = document.getElementById('course-filter');
+      select.style.display = 'block';
+      select.innerHTML = '<option value="">Alle Kurse</option>';
+      courses.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c;
+        opt.textContent = c;
+        if (c === selectedCourse) opt.selected = true;
+        select.appendChild(opt);
+      });
     });
 }
 
 function updateVehicles() {
-  const url = selectedLine ? `/vehicles?line=${encodeURIComponent(selectedLine)}` : '/vehicles';
+  let url = '/vehicles';
+  const params = [];
+  if (selectedLine) {
+    params.push(`line=${encodeURIComponent(selectedLine)}`);
+  }
+  if (selectedCourse) {
+    params.push(`course=${encodeURIComponent(selectedCourse)}`);
+  }
+  if (params.length > 0) {
+    url += '?' + params.join('&');
+  }
   fetch(url)
     .then(r => r.json())
     .then(data => {
@@ -55,12 +86,38 @@ function updateVehicles() {
 }
 
 document.getElementById('line-filter').addEventListener('change', ev => {
-  const line = ev.target.value;
-  if (line) {
-    window.location.search = '?line=' + encodeURIComponent(line);
+  selectedLine = ev.target.value;
+  selectedCourse = '';
+  const courseSelect = document.getElementById('course-filter');
+  if (selectedLine) {
+    loadCourses(selectedLine);
+    const params = new URLSearchParams(window.location.search);
+    params.set('line', selectedLine);
+    params.delete('course');
+    window.history.replaceState({}, '', `?${params.toString()}`);
   } else {
-    window.location.search = location.pathname;
+    courseSelect.style.display = 'none';
+    courseSelect.innerHTML = '<option value="">Alle Kurse</option>';
+    const params = new URLSearchParams(window.location.search);
+    params.delete('line');
+    params.delete('course');
+    const url = params.toString() ? `?${params.toString()}` : location.pathname;
+    window.history.replaceState({}, '', url);
+    updateVehicles();
   }
+  updateVehicles();
+});
+
+document.getElementById('course-filter').addEventListener('change', ev => {
+  selectedCourse = ev.target.value;
+  const params = new URLSearchParams(window.location.search);
+  if (selectedCourse) {
+    params.set('course', selectedCourse);
+  } else {
+    params.delete('course');
+  }
+  window.history.replaceState({}, '', `?${params.toString()}`);
+  updateVehicles();
 });
 
 loadLines();

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,10 +21,14 @@
   <select id="line-filter">
     <option value="">Alle Linien</option>
   </select>
+  <select id="course-filter" style="display:none">
+    <option value="">Alle Kurse</option>
+  </select>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script>
     const INITIAL_LINE = "{{ line }}";
+    const INITIAL_COURSE = "{{ course }}";
   </script>
   <script src="/static/map.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- generate list of lines from the GTFS feed via `generate_line_list.py`
- read `data/line.txt` in new `/lines` endpoint and provide `/courses` API
- filter vehicles by line and course
- expose course selection dropdown in the map
- document new script in README

## Testing
- `python -m py_compile app.py generate_line_list.py efa_stop_visits.py efa_tram_monitor.py`
- `python generate_line_list.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859ec3f34308321ada68b967dde5083