### PR TITLE
Add txt.py for GTFS export

### DIFF
--- a/txt.py
+++ b/txt.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Save the current GTFS-Realtime feed as a text file."""
+
+import json
+from app import load_gtfs_feed
+
+
+def main() -> None:
+    vehicles = load_gtfs_feed()
+    with open("data/gtfs.txt", "w", encoding="utf-8") as f:
+        json.dump(vehicles, f, indent=2, ensure_ascii=False)
+    print("Saved GTFS feed to data/gtfs.txt")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `txt.py` script to export the GTFS-Realtime feed into a text file

## Testing
- `python -m py_compile app.py generate_line_list.py efa_tram_monitor.py efa_stop_visits.py txt.py`
- `python txt.py` *(fails to fetch GTFS feed due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685a554f131083218bf1ed9e5a9a500e