### PR TITLE
Display course info when no position available

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,8 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet-rotatedmarker/leaflet.rotatedMarker.js"></script>
   <style>
-    #map { height: 100vh; }
+    #map { height: 70vh; }
+    #course-list { padding: 1em; font-family: sans-serif; }
     .tram-marker {
       width: 0;
       height: 0;
@@ -25,6 +26,7 @@
     <option value="">Alle Kurse</option>
   </select>
   <div id="map"></div>
+  <div id="course-list"></div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script>
     const INITIAL_LINE = "{{ line }}";


### PR DESCRIPTION
## Summary
- extend server to extract trip updates and expose `/missing_courses`
- shrink map height and add `#course-list` element
- show courses without vehicle position in new list

## Testing
- `python -m py_compile app.py efa_stop_visits.py efa_tram_monitor.py generate_line_list.py txt.py`

------
https://chatgpt.com/codex/tasks/task_e_685a6385544c83219367a581006ddf14