### PR TITLE
Update refresh interval to 10s

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Open `http://localhost:8021` in your browser.
 
 Only the Essen tram lines (101, 103, 105, 106, 107, 108, 109) are displayed.
 Use the dropdown or the URL parameter `?line=107` to focus on a single line.
-The map refreshes automatically every 15 seconds.
+The map refreshes automatically every 10 seconds.
 
 ### Generate line list
 

--- a/static/map.js
+++ b/static/map.js
@@ -157,4 +157,4 @@ document.getElementById('course-filter').addEventListener('change', ev => {
 loadLines();
 updateVehicles();
 updateMissingCourses();
-setInterval(() => { updateVehicles(); updateMissingCourses(); }, 15000);
+setInterval(() => { updateVehicles(); updateMissingCourses(); }, 10000);


### PR DESCRIPTION
## Summary
- adjust automatic refresh interval from 15 to 10 seconds
- document new refresh interval in README

## Testing
- `python -m py_compile app.py efa_stop_visits.py efa_tram_monitor.py generate_line_list.py txt.py`
- `python app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685a6b4e28088321880c542ea59cc302