### PR TITLE
Filter Essen lines by prefix

### DIFF
--- a/efa_stop_visits.py
+++ b/efa_stop_visits.py
@@ -5,6 +5,11 @@ import requests
 ESSEN_LINES = {"101", "103", "105", "106", "107", "108", "109"}
 
 
+def is_essen_line(line: str) -> bool:
+    """Return True if the line starts with one of the Essen prefixes."""
+    return any(line.startswith(l) for l in ESSEN_LINES)
+
+
 def fetch_visits_by_name(name: str) -> None:
     """Fetch and display stop visits using a stop name."""
     url = "https://efa.vrr.de/standard/XML_STOPVISIT_REQUEST"
@@ -26,7 +31,7 @@ def fetch_visits_by_name(name: str) -> None:
         for v in visits:
             j = v["monitoredVehicleJourney"]
             line = str(j.get("lineRef"))
-            if line not in ESSEN_LINES:
+            if not is_essen_line(line):
                 continue
             stop_call = j.get("monitoredCall", {})
             stop_name = stop_call.get("stopPointName") or stop_call.get(


### PR DESCRIPTION
## Summary
- add `is_essen_line` helper
- filter lines based on prefix instead of exact match

## Testing
- `python -m py_compile app.py efa_stop_visits.py efa_tram_monitor.py generate_line_list.py txt.py`
- `python app.py` (terminated immediately)

------
https://chatgpt.com/codex/tasks/task_e_685a6d0888548321b8c7a0c05d346256