### PR TITLE
Sort lines and courses ascending

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,13 +130,13 @@ def get_lines() -> Any:
         vehicles = load_gtfs_feed()
         lines = sorted({v["line"] for v in vehicles})
     lines = [l for l in lines if is_essen_line(l)]
-    return jsonify(sorted(lines, key=lambda x: int(x), reverse=True))
+    return jsonify(sorted(lines, key=lambda x: int(x)))
 
 
 @app.route("/essen_lines")
 def get_essen_lines() -> Any:
     """Return the configured Essen tram lines."""
-    return jsonify(sorted(ESSEN_LINES, key=lambda x: int(x), reverse=True))
+    return jsonify(sorted(ESSEN_LINES, key=lambda x: int(x)))
 
 
 @app.route("/courses")
@@ -180,6 +180,7 @@ def get_missing_courses() -> Any:
     for c in result:
         if c.get("next_stop"):
             c["next_stop"] = get_stop_name(str(c["next_stop"]))
+    result.sort(key=lambda c: (int(c["line"]), str(c["course"])))
     return jsonify(result)
 
 

--- a/static/map.js
+++ b/static/map.js
@@ -136,7 +136,11 @@ function updateMissingCourses() {
         }
         return;
       }
-      data.sort((a, b) => parseInt(b.line, 10) - parseInt(a.line, 10));
+      data.sort((a, b) => {
+        const lineDiff = parseInt(a.line, 10) - parseInt(b.line, 10);
+        if (lineDiff !== 0) return lineDiff;
+        return parseInt(a.course, 10) - parseInt(b.course, 10);
+      });
       const seen = new Set();
       data.forEach(c => {
         const key = `${c.line}-${c.course}`;


### PR DESCRIPTION
## Summary
- sort line lists ascending in `app.py`
- sort missing courses by line and course in `app.py`
- sort missing course output by line and course in `static/map.js`

## Testing
- `python -m py_compile app.py efa_stop_visits.py efa_tram_monitor.py generate_line_list.py txt.py`
- `node -e "require('fs').readFileSync('static/map.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_685a75f2a5dc83219845184d992512d1