### PR TITLE
Fix course list refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The web application reads this file for the dropdown if it exists.
 If a file `data/stop_names.csv` with `stop_id,name` pairs is present, the
 application will show the stop name instead of the ID for missing course
 information. Otherwise the raw ID is used.
+If a file `data/headsigns.csv` with `trip_id,headsign` pairs exists, the
+application will show the trip headsign in the list of missing courses.
 
 ## VRR Stop Visit Script
 

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ def is_essen_line(line: str) -> bool:
     return any(line.startswith(l) for l in ESSEN_LINES)
 
 _STOP_NAME_MAP: Dict[str, str] = {}
+_HEADSIGN_MAP: Dict[str, str] = {}
 
 def _load_stop_names() -> None:
     """Load stop_id->name mapping from data/stop_names.csv if present."""
@@ -27,11 +28,27 @@ def _load_stop_names() -> None:
     except FileNotFoundError:
         pass
 
+def _load_headsigns() -> None:
+    """Load trip_id->headsign mapping from data/headsigns.csv if present."""
+    path = os.path.join("data", "headsigns.csv")
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                tid, headsign = line.rstrip().split(",", 1)
+                _HEADSIGN_MAP[tid] = headsign
+    except FileNotFoundError:
+        pass
+
 _load_stop_names()
+_load_headsigns()
 
 def get_stop_name(stop_id: str) -> str:
     """Return the stop name for the given ID if known."""
     return _STOP_NAME_MAP.get(stop_id, stop_id)
+
+def get_headsign(trip_id: str) -> str:
+    """Return the headsign for the given trip ID if known."""
+    return _HEADSIGN_MAP.get(trip_id, "")
 import requests
 from google.transit import gtfs_realtime_pb2
 
@@ -111,6 +128,7 @@ def load_gtfs_feed() -> List[Dict[str, Any]]:
                     "course": trip.trip_id,
                     "vehicle": vehicle_id,
                     "next_stop": next_stop,
+                    "headsign": get_headsign(trip.trip_id),
                 }
             )
 

--- a/static/map.js
+++ b/static/map.js
@@ -141,11 +141,16 @@ function updateMissingCourses() {
         if (lineDiff !== 0) return lineDiff;
         return parseInt(a.course, 10) - parseInt(b.course, 10);
       });
+      courseListEl.innerHTML = '';
+      for (const key in courseDivs) {
+        delete courseDivs[key];
+      }
       const seen = new Set();
       data.forEach(c => {
         const key = `${c.line}-${c.course}`;
         const vehicle = c.vehicle ? ` (${c.vehicle})` : '';
-        const text = `${formatLine(c.line)} | ${formatCourse(c.course)}${vehicle} -> ${c.next_stop}`;
+        const headsign = c.headsign ? ` (${c.headsign})` : '';
+        const text = `${formatLine(c.line)} | ${formatCourse(c.course)}${vehicle} -> ${c.next_stop}${headsign}`;
         seen.add(key);
         let div = courseDivs[key];
         if (div) {


### PR DESCRIPTION
## Summary
- clear course list contents when updating missing courses
- show trip headsign when available

## Testing
- `python -m py_compile app.py efa_stop_visits.py efa_tram_monitor.py txt.py generate_line_list.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a773e80a88321abcf902c029c64d0