### PR TITLE
Fix line dropdown and realtime sorting

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,6 +147,8 @@ def get_lines() -> Any:
     except FileNotFoundError:
         vehicles = load_gtfs_feed()
         lines = sorted({v["line"] for v in vehicles})
+        if not lines:
+            lines = sorted(ESSEN_LINES)
     lines = [l for l in lines if is_essen_line(l)]
     return jsonify(sorted(lines, key=lambda x: int(x)))
 

--- a/static/map.js
+++ b/static/map.js
@@ -8,7 +8,6 @@ let selectedCourse = typeof INITIAL_COURSE !== 'undefined' ? INITIAL_COURSE : ''
 const markers = {};
 const courseTableBody = document.getElementById('course-table-body');
 const essenSelect = document.getElementById('essen-line-filter');
-const courseRows = {};
 
 function formatLine(line) {
   const digits = String(line).replace(/\D/g, '');
@@ -137,9 +136,6 @@ function updateMissingCourses() {
         cell.textContent = 'Keine Fahrten ohne Standort.';
         row.appendChild(cell);
         courseTableBody.appendChild(row);
-        for (const key in courseRows) {
-          delete courseRows[key];
-        }
         return;
       }
       data.sort((a, b) => {
@@ -147,47 +143,22 @@ function updateMissingCourses() {
         if (lineDiff !== 0) return lineDiff;
         return parseInt(a.course, 10) - parseInt(b.course, 10);
       });
-      const seen = new Set();
       data.forEach(c => {
-        const key = `${c.line}-${c.course}`;
-        const headsign = c.headsign || '';
-        const stop = c.next_stop || '';
-        seen.add(key);
-        let row = courseRows[key];
-        if (row) {
-          const cells = row.children;
-          if (
-            cells[0].textContent !== formatLine(c.line) ||
-            cells[1].textContent !== formatCourse(c.course) ||
-            cells[2].textContent !== stop ||
-            cells[3].textContent !== headsign
-          ) {
-            cells[0].textContent = formatLine(c.line);
-            cells[1].textContent = formatCourse(c.course);
-            cells[2].textContent = stop;
-            cells[3].textContent = headsign;
-            row.classList.add('updated');
-            setTimeout(() => row.classList.remove('updated'), 2000);
-          }
-        } else {
-          row = document.createElement('tr');
-          row.classList.add('updated');
-          const vals = [formatLine(c.line), formatCourse(c.course), stop, headsign];
-          vals.forEach(v => {
-            const td = document.createElement('td');
-            td.textContent = v;
-            row.appendChild(td);
-          });
-          setTimeout(() => row.classList.remove('updated'), 2000);
-          courseRows[key] = row;
-        }
+        const row = document.createElement('tr');
+        row.classList.add('updated');
+        const vals = [
+          formatLine(c.line),
+          formatCourse(c.course),
+          c.next_stop || '',
+          c.headsign || ''
+        ];
+        vals.forEach(v => {
+          const td = document.createElement('td');
+          td.textContent = v;
+          row.appendChild(td);
+        });
+        setTimeout(() => row.classList.remove('updated'), 2000);
         courseTableBody.appendChild(row);
-      });
-      Object.keys(courseRows).forEach(k => {
-        if (!seen.has(k)) {
-          courseTableBody.removeChild(courseRows[k]);
-          delete courseRows[k];
-        }
       });
     });
 }


### PR DESCRIPTION
## Summary
- fix realtime sorting by rebuilding missing course table
- return default lines if feed is empty

## Testing
- `python -m py_compile app.py efa_stop_visits.py efa_tram_monitor.py generate_line_list.py`

------
https://chatgpt.com/codex/tasks/task_e_685a7ca2e4c88321ba46450dd3faddf5